### PR TITLE
Update plexus-container-default to 1.5.5

### DIFF
--- a/modello-plugins/modello-plugin-dom4j/src/test/java/org/codehaus/modello/plugin/dom4j/Dom4jGeneratorTest.java
+++ b/modello-plugins/modello-plugin-dom4j/src/test/java/org/codehaus/modello/plugin/dom4j/Dom4jGeneratorTest.java
@@ -49,7 +49,7 @@ public class Dom4jGeneratorTest
     public void testDom4jGenerator()
         throws Throwable
     {
-        ModelloCore modello = (ModelloCore) container.lookup( ModelloCore.ROLE );
+        ModelloCore modello = (ModelloCore) lookup( ModelloCore.ROLE );
 
         Model model = modello.loadModel( getXmlResourceReader( "/maven.mdo" ) );
 

--- a/modello-plugins/modello-plugin-stax/src/test/java/org/codehaus/modello/generator/xml/stax/AbstractStaxGeneratorTestCase.java
+++ b/modello-plugins/modello-plugin-stax/src/test/java/org/codehaus/modello/generator/xml/stax/AbstractStaxGeneratorTestCase.java
@@ -45,7 +45,7 @@ public abstract class AbstractStaxGeneratorTestCase
     {
         super.setUp();
 
-        modello = (ModelloCore) container.lookup( ModelloCore.ROLE );
+        modello = (ModelloCore) lookup( ModelloCore.ROLE );
     }
 
     protected void verifyModel( Model model, String className )

--- a/modello-plugins/modello-plugin-xdoc/src/test/java/org/codehaus/modello/plugin/xdoc/XdocGeneratorTest.java
+++ b/modello-plugins/modello-plugin-xdoc/src/test/java/org/codehaus/modello/plugin/xdoc/XdocGeneratorTest.java
@@ -70,7 +70,7 @@ public class XdocGeneratorTest
     private void checkMavenXdocGenerator()
         throws Exception
     {
-        ModelloCore modello = (ModelloCore) container.lookup( ModelloCore.ROLE );
+        ModelloCore modello = (ModelloCore) lookup( ModelloCore.ROLE );
 
         Model model = modello.loadModel( getXmlResourceReader( "/maven.mdo" ) );
 

--- a/modello-plugins/modello-plugin-xml/src/test/java/org/codehaus/modello/plugins/xml/XmlModelloPluginTest.java
+++ b/modello-plugins/modello-plugin-xml/src/test/java/org/codehaus/modello/plugins/xml/XmlModelloPluginTest.java
@@ -54,7 +54,7 @@ public class XmlModelloPluginTest
     public void testXmlPlugin()
         throws Exception
     {
-        ModelloCore modello = (ModelloCore) container.lookup( ModelloCore.ROLE );
+        ModelloCore modello = (ModelloCore) lookup( ModelloCore.ROLE );
 
         Model model = modello.loadModel( getTestFile( "src/test/resources/model.mdo" ) );
 

--- a/modello-plugins/modello-plugin-xpp3/src/test/java/org/codehaus/modello/generator/xml/xpp3/AbstractElementTest.java
+++ b/modello-plugins/modello-plugin-xpp3/src/test/java/org/codehaus/modello/generator/xml/xpp3/AbstractElementTest.java
@@ -43,7 +43,7 @@ public class AbstractElementTest
     public void testAbstract()
         throws Throwable
     {
-        ModelloCore modello = (ModelloCore) container.lookup( ModelloCore.ROLE );
+        ModelloCore modello = (ModelloCore) lookup( ModelloCore.ROLE );
 
         Model model = modello.loadModel( getXmlResourceReader( "/abstract.mdo" ) );
 

--- a/modello-plugins/modello-plugin-xsd/src/test/java/org/codehaus/modello/plugin/xsd/ChangesXsdGeneratorTest.java
+++ b/modello-plugins/modello-plugin-xsd/src/test/java/org/codehaus/modello/plugin/xsd/ChangesXsdGeneratorTest.java
@@ -42,7 +42,7 @@ public class ChangesXsdGeneratorTest
     public void testXsdGenerator()
         throws Throwable
     {
-        ModelloCore modello = (ModelloCore) container.lookup( ModelloCore.ROLE );
+        ModelloCore modello = (ModelloCore) lookup( ModelloCore.ROLE );
 
         Model model = modello.loadModel( getXmlResourceReader( "/changes.mdo" ) );
 

--- a/modello-plugins/modello-plugin-xsd/src/test/java/org/codehaus/modello/plugin/xsd/XsdGeneratorTest.java
+++ b/modello-plugins/modello-plugin-xsd/src/test/java/org/codehaus/modello/plugin/xsd/XsdGeneratorTest.java
@@ -47,7 +47,7 @@ public class XsdGeneratorTest
     public void testXsdGenerator()
         throws Throwable
     {
-        ModelloCore modello = (ModelloCore) container.lookup( ModelloCore.ROLE );
+        ModelloCore modello = (ModelloCore) lookup( ModelloCore.ROLE );
 
         Model model = modello.loadModel( getXmlResourceReader( "/maven.mdo" ) );
 

--- a/pom.xml
+++ b/pom.xml
@@ -307,7 +307,7 @@
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-container-default</artifactId>
-        <version>1.0-alpha-30</version>
+        <version>1.5.5</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.plexus</groupId>


### PR DESCRIPTION
Some unit tests used deprecated API which was removed in later
versions of plexus-container-default.
